### PR TITLE
feat: updates to income validation logic

### DIFF
--- a/sites/public/src/components/assistant/controller.ts
+++ b/sites/public/src/components/assistant/controller.ts
@@ -51,8 +51,10 @@ export const createAssistantController = (script: AssistantScript) => {
           invalidInputCount = 0
           invalidInputs = []
         } else {
-          responseText = script.fallbackInvalid
+          //  Use specific invalid message if available
+          responseText = question.invalidMessage || script.fallbackInvalid
         }
+
         return { responseText, flowEnded: false }
       } else {
         validResponses[currentStep] = input
@@ -65,12 +67,14 @@ export const createAssistantController = (script: AssistantScript) => {
             ...question.dynamicQuestionHandler(input, Object.values(validResponses)),
           ]
         }
+
         currentStep++
         return currentStep < currentQuestions.length
           ? { responseText: currentQuestions[currentStep].question, flowEnded: false }
           : { responseText: "", flowEnded: true }
       }
     }
+
     return { responseText: "An error occurred", flowEnded: false }
   }
 

--- a/sites/public/src/components/assistant/scripts/incomeScript.ts
+++ b/sites/public/src/components/assistant/scripts/incomeScript.ts
@@ -9,6 +9,7 @@ const INCOME_QUESTIONS: AssistantQuestion[] = [
       const num = parseInt(value)
       return !isNaN(num) && num > 0
     },
+    invalidMessage: "Please enter a valid number greater than 0 for household income earners.",
     dynamicQuestionHandler: (input: string) => {
       const questionsToAdd: AssistantQuestion[] = []
       const count = parseInt(input)
@@ -24,6 +25,7 @@ const INCOME_QUESTIONS: AssistantQuestion[] = [
               const cleaned = value.replace(/[$,]/g, "")
               return /^[0-9]+(\.[0-9]+)?$/.test(cleaned) && parseFloat(cleaned) > 0
             },
+            invalidMessage: "Please enter a valid hourly rate, like 20 or $18.50.",
           },
           {
             id: `hours_per_week_${i + 1}`,
@@ -33,6 +35,7 @@ const INCOME_QUESTIONS: AssistantQuestion[] = [
               const num = parseInt(value)
               return !isNaN(num) && num > 0 && num <= 168
             },
+            invalidMessage: "Please enter a number between 1 and 168 for hours worked per week.",
           }
         )
       }
@@ -44,8 +47,8 @@ const INCOME_QUESTIONS: AssistantQuestion[] = [
 export const incomeAssistantScript: AssistantScript = {
   welcomeMessage: "Welcome! Let's calculate your income.",
   questions: INCOME_QUESTIONS,
-  fallbackInvalid: "Invalid answer.",
-  fallbackError: "Error processing responses.",
+  fallbackInvalid: "Please check your answer and try again.",
+  fallbackError: "Sorry, there was an error processing your responses.",
   getFinalResult: (responses: string[]) => {
     const householdCount = parseInt(responses[0], 10)
     if (isNaN(householdCount) || householdCount <= 0) {

--- a/sites/public/src/components/assistant/types.ts
+++ b/sites/public/src/components/assistant/types.ts
@@ -10,6 +10,7 @@ export interface AssistantQuestion {
   question: string
   type: string
   validation?: (value: string) => boolean
+  invalidMessage?: string
   dynamicQuestionHandler?: (input: string, responses: string[]) => AssistantQuestion[]
 }
 

--- a/sites/public/src/pages/applications/financial/income.tsx
+++ b/sites/public/src/pages/applications/financial/income.tsx
@@ -121,6 +121,7 @@ const ApplicationIncome = () => {
 
   const handleConfirmEstimate = (estimate: string) => {
     setValue("income", estimate)
+    setValue("incomePeriod", "perYear")
     console.log("Income form updated with estimate:", estimate)
   }
 


### PR DESCRIPTION
This PR addresses #<insert-issue-number-here>

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR implements support for custom invalid messages per question in the income assistant flow.

### Summary of changes:
- Updated the `AssistantQuestion` type to include an optional `invalidMessage` field.
- Added `invalidMessage` strings to each question in the `incomeAssistantScript` for more helpful feedback.
- Modified `handleUserInputLogic` in `createAssistantController` to use the question-specific message when validation fails, falling back to the script’s default if none is provided.
- Preserved fallback-to-LLM behavior when the user submits two invalid inputs in a row.

This update improves clarity and user experience by providing more instructive feedback for invalid responses.

## How Can This Be Tested/Reviewed?

1. Start the assistant and walk through the income questions.
2. Enter valid and invalid inputs for:
   - Number of earners
   - Hourly wage
   - Hours per week
3. Confirm that:
   - Valid responses advance the assistant.
   - Invalid responses show the correct, question-specific error messages.
   - After two invalid inputs, the assistant defers to LLM for guidance.
4. Check that dynamic question handling still works when entering more than one earner.

No special configuration is required.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
